### PR TITLE
[codex] Fix sort key collision for separatorless persistence ids

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,8 @@ lazy val `snapshot-base` = (project in file("snapshot/snapshot-base"))
   .settings(
     name := "pekko-persistence-dynamodb-snapshot-base",
     libraryDependencies ++= Seq(
-      pekko.persistence(pekkoVersion)
+      pekko.persistence(pekkoVersion),
+      scalatest.scalatest(scalaTest32Version) % Test
     )
   ).dependsOn(base)
 

--- a/docs/src/sphinx/customize.md
+++ b/docs/src/sphinx/customize.md
@@ -178,6 +178,7 @@ The following two implementations are available for built-in use.
   - `skey = ${persistenceId.body}-${sequenceNumber}`
   - e.g. `875e6ce0425e4d2b8203f3b44b9b531a`, `persistenceId.body` is `875e6ce0425e4d2b8203f3b44b9b531a`.
   - Use `persistenceId.body` as the prefix since `shard-count` may cause multiple `persistenceId`s events to be stored in the same shard.
+  - If the `persistenceId` does not contain the separator, the full `persistenceId` is used as the prefix: `${persistenceId}-${sequenceNumber}`.
 
 
 #### Configure your own implementation
@@ -230,6 +231,11 @@ The following two implementations are available for built-in use.
   - `skey = ${persistenceId.body}-${sequenceNumber}`
   - e.g. `875e6ce0425e4d2b8203f3b44b9b531a`, `persistenceId.body` is `875e6ce0425e4d2b8203f3b44b9b531a`.
   - Use `persistenceId.body` as the prefix since `shard-count` may cause multiple `persistenceId`s events to be stored in the same shard.
+  - If the `persistenceId` does not contain the separator, the full `persistenceId` is used as the prefix: `${persistenceId}-${sequenceNumber}`.
+
+```{admonition} Compatibility note
+Older versions stored `PersistenceIdWithSeqNr` sort keys as only `${sequenceNumber}` when the `persistenceId` did not contain the separator. New writes use `${persistenceId}-${sequenceNumber}` to avoid overwriting records that share the same `(pkey, sequenceNumber)`. Existing rows that were written with the old sort-key format can still be read through the `persistence-id` / `sequence-nr` secondary index, but delete and update operations calculate the table primary key from the current resolver. If you already have rows with the old format, migrate those rows to the new sort-key format before relying on delete or update for separator-less persistence ids.
+```
 
 #### Configure your own implementation
     
@@ -534,4 +540,3 @@ j5ik2o.dynamo-db-????? {
   }
 }
 ```
-

--- a/journal/journal-base/src/main/scala/com/github/j5ik2o/pekko/persistence/dynamodb/journal/SortKeyResolver.scala
+++ b/journal/journal-base/src/main/scala/com/github/j5ik2o/pekko/persistence/dynamodb/journal/SortKeyResolver.scala
@@ -54,6 +54,21 @@ object SortKeyResolverProvider {
 
 object SortKeyResolver {
 
+  private[journal] def persistenceIdWithSeqNrSKey(
+      persistenceId: PersistenceId,
+      sequenceNumber: SequenceNumber,
+      separator: String
+  ): String = {
+    val bodyOpt = new PersistenceIdOps(persistenceId, separator).body
+    val seq     = sequenceNumber.value
+    bodyOpt match {
+      case Some(pid) =>
+        "%s-%019d".format(pid, seq)
+      case None =>
+        "%s-%019d".format(persistenceId.asString, seq)
+    }
+  }
+
   final class SeqNr extends SortKeyResolver {
 
     // ${sequenceNumber}
@@ -71,17 +86,9 @@ object SortKeyResolver {
       pluginContext.pluginConfig.sourceConfig
         .getAs[String]("persistence-id-separator").getOrElse(PersistenceId.Separator)
 
-    // ${persistenceId.body}-${sequenceNumber}
+    // ${persistenceId.bodyOrFullPersistenceId}-${sequenceNumber}
     override def resolve(persistenceId: PersistenceId, sequenceNumber: SequenceNumber): SortKey = {
-      val bodyOpt = persistenceId.body
-      val seq     = sequenceNumber.value
-      val skey = bodyOpt match {
-        case Some(pid) =>
-          "%s-%019d".format(pid, seq)
-        case None => // fallback
-          "%019d".format(seq)
-      }
-      SortKey(skey)
+      SortKey(persistenceIdWithSeqNrSKey(persistenceId, sequenceNumber, separator))
     }
 
   }

--- a/journal/journal-base/src/test/scala/com/github/j5ik2o/pekko/persistence/dynamodb/journal/SortKeyResolverSpec.scala
+++ b/journal/journal-base/src/test/scala/com/github/j5ik2o/pekko/persistence/dynamodb/journal/SortKeyResolverSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Junichi Kato
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.j5ik2o.pekko.persistence.dynamodb.journal
+
+import com.github.j5ik2o.pekko.persistence.dynamodb.model.{ PersistenceId, SequenceNumber }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+final class SortKeyResolverSpec extends AnyFreeSpec with Matchers {
+
+  "PersistenceIdWithSeqNr" - {
+    "keeps the existing body-based key when persistence-id contains the separator" in {
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("counter-875e6ce0425e4d2b8203f3b44b9b531a"),
+        SequenceNumber(1),
+        PersistenceId.Separator
+      ) shouldBe "875e6ce0425e4d2b8203f3b44b9b531a-0000000000000000001"
+    }
+
+    "includes the full persistence-id when persistence-id does not contain the separator" in {
+      val sequenceNumber = SequenceNumber(1)
+
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("01HZX6K5VJAS2Y0P7FNKX5A2A1"),
+        sequenceNumber,
+        PersistenceId.Separator
+      ) shouldBe "01HZX6K5VJAS2Y0P7FNKX5A2A1-0000000000000000001"
+
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("01HZX6K5VJAS2Y0P7FNKX5A2A2"),
+        sequenceNumber,
+        PersistenceId.Separator
+      ) shouldBe "01HZX6K5VJAS2Y0P7FNKX5A2A2-0000000000000000001"
+    }
+  }
+
+}

--- a/snapshot/snapshot-base/src/main/scala/com/github/j5ik2o/pekko/persistence/dynamodb/snapshot/SortKeyResolver.scala
+++ b/snapshot/snapshot-base/src/main/scala/com/github/j5ik2o/pekko/persistence/dynamodb/snapshot/SortKeyResolver.scala
@@ -54,6 +54,21 @@ object SortKeyResolverProvider {
 
 object SortKeyResolver {
 
+  private[snapshot] def persistenceIdWithSeqNrSKey(
+      persistenceId: PersistenceId,
+      sequenceNumber: SequenceNumber,
+      separator: String
+  ): String = {
+    val bodyOpt = new PersistenceIdOps(persistenceId, separator).body
+    val seq     = sequenceNumber.value
+    bodyOpt match {
+      case Some(pid) =>
+        "%s-%019d".format(pid, seq)
+      case None =>
+        "%s-%019d".format(persistenceId.asString, seq)
+    }
+  }
+
   final class SeqNr extends SortKeyResolver {
 
     // ${sequenceNumber}
@@ -72,17 +87,9 @@ object SortKeyResolver {
     override def separator: String =
       pluginConfig.sourceConfig.getAs[String]("persistence-id-separator").getOrElse(PersistenceId.Separator)
 
-    // ${persistenceId.body}-${sequenceNumber}
+    // ${persistenceId.bodyOrFullPersistenceId}-${sequenceNumber}
     override def resolve(persistenceId: PersistenceId, sequenceNumber: SequenceNumber): SortKey = {
-      val bodyOpt = persistenceId.body
-      val seq     = sequenceNumber.value
-      val skey = bodyOpt match {
-        case Some(pid) =>
-          "%s-%019d".format(pid, seq)
-        case None => // fallback
-          "%019d".format(seq)
-      }
-      SortKey(skey)
+      SortKey(persistenceIdWithSeqNrSKey(persistenceId, sequenceNumber, separator))
     }
 
   }

--- a/snapshot/snapshot-base/src/test/scala/com/github/j5ik2o/pekko/persistence/dynamodb/snapshot/SortKeyResolverSpec.scala
+++ b/snapshot/snapshot-base/src/test/scala/com/github/j5ik2o/pekko/persistence/dynamodb/snapshot/SortKeyResolverSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Junichi Kato
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.j5ik2o.pekko.persistence.dynamodb.snapshot
+
+import com.github.j5ik2o.pekko.persistence.dynamodb.model.{ PersistenceId, SequenceNumber }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+final class SortKeyResolverSpec extends AnyFreeSpec with Matchers {
+
+  "PersistenceIdWithSeqNr" - {
+    "keeps the existing body-based key when persistence-id contains the separator" in {
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("counter-875e6ce0425e4d2b8203f3b44b9b531a"),
+        SequenceNumber(1),
+        PersistenceId.Separator
+      ) shouldBe "875e6ce0425e4d2b8203f3b44b9b531a-0000000000000000001"
+    }
+
+    "includes the full persistence-id when persistence-id does not contain the separator" in {
+      val sequenceNumber = SequenceNumber(1)
+
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("01HZX6K5VJAS2Y0P7FNKX5A2A1"),
+        sequenceNumber,
+        PersistenceId.Separator
+      ) shouldBe "01HZX6K5VJAS2Y0P7FNKX5A2A1-0000000000000000001"
+
+      SortKeyResolver.persistenceIdWithSeqNrSKey(
+        PersistenceId("01HZX6K5VJAS2Y0P7FNKX5A2A2"),
+        sequenceNumber,
+        PersistenceId.Separator
+      ) shouldBe "01HZX6K5VJAS2Y0P7FNKX5A2A2-0000000000000000001"
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

- Fix `PersistenceIdWithSeqNr` sort-key generation for journal and snapshot rows when the persistence id has no configured separator.
- Preserve the existing body-based sort-key format when the persistence id does contain the separator.
- Add focused regression tests for both journal and snapshot sort-key resolvers.
- Document the compatibility and migration impact for rows written with the old separator-less sort-key format.

## Root Cause

When `persistenceId.body` was empty, the fallback sort key used only the zero-padded sequence number. Different persistence ids assigned to the same partition key shard could therefore produce the same `(pkey, skey)` and overwrite each other.

## Validation

- `journal-base/Test/testOnly com.github.j5ik2o.pekko.persistence.dynamodb.journal.SortKeyResolverSpec`
- `snapshot-base/Test/testOnly com.github.j5ik2o.pekko.persistence.dynamodb.snapshot.SortKeyResolverSpec`
- `journal-base/scalafmtCheck`
- `journal-base/Test/scalafmtCheck`
- `snapshot-base/scalafmtCheck`
- `snapshot-base/Test/scalafmtCheck`
- `scalafmtSbtCheck`
- `git diff --check`

Closes #830

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the DynamoDB primary-key (`skey`) format for `PersistenceIdWithSeqNr` when persistence ids lack the separator, which can impact compatibility with existing stored rows and affects delete/update key calculation.
> 
> **Overview**
> Fixes a collision bug in `PersistenceIdWithSeqNr` sort-key generation for both **journal** and **snapshot** rows: when a persistence id lacks the configured separator, new `skey` values now include the *full* persistence id (instead of only the zero-padded sequence number), preventing overwrites within a shard.
> 
> Adds focused ScalaTest regression specs for journal/snapshot sort-key formatting, updates docs with a **compatibility/migration note**, and wires `scalatest` into `snapshot-base` so its new tests run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c4482e5c78b8901f77bade35f6f1d20d2be69e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->